### PR TITLE
Refine the Release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -19,3 +19,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          access: public


### PR DESCRIPTION
## Description

- Removes unnecessary `build` step
- Remove commented `test` step 
- Add's `access: public` on the release step

## Related Issue(s)

Closes https://github.com/FlowFuse/nr-tables-nodes/issues/5